### PR TITLE
Basic stub with method and url/path matcher

### DIFF
--- a/match.go
+++ b/match.go
@@ -23,3 +23,22 @@ func Path(path string) URLMatcher {
 		return url.Path == strings.TrimSuffix(path, "/")
 	}
 }
+
+func defaultMatchers(method string, url URLMatcher) []requestMatcherFunc {
+	return []requestMatcherFunc{
+		methodMatcher(method),
+		urlMatcher(url),
+	}
+}
+
+func methodMatcher(method string) requestMatcherFunc {
+	return func(_ *stub, r *http.Request) bool {
+		return r.Method == method
+	}
+}
+
+func urlMatcher(matcher URLMatcher) requestMatcherFunc {
+	return func(_ *stub, r *http.Request) bool {
+		return matcher(r.URL)
+	}
+}

--- a/match.go
+++ b/match.go
@@ -1,0 +1,25 @@
+package mockaso
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type requestMatcherFunc func(*stub, *http.Request) bool
+
+type URLMatcher func(*url.URL) bool
+
+// URL will match http request when the value specified is equals to the full request URL.
+func URL(u string) URLMatcher {
+	return func(url *url.URL) bool {
+		return u == url.String()
+	}
+}
+
+// Path will match http request when the value specified is equals to the request URL path part.
+func Path(path string) URLMatcher {
+	return func(url *url.URL) bool {
+		return url.Path == strings.TrimSuffix(path, "/")
+	}
+}

--- a/match_test.go
+++ b/match_test.go
@@ -1,0 +1,85 @@
+package mockaso_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/royhq/mockaso"
+)
+
+func TestURL(t *testing.T) {
+	t.Parallel()
+
+	reqURL := "/api/users?page=1&size=20"
+	httpReq := httptest.NewRequest(http.MethodGet, reqURL, http.NoBody)
+
+	testCases := map[string]struct {
+		matchURL      string
+		expectedMatch bool
+	}{
+		"should return true when url matched": {
+			matchURL:      "/api/users?page=1&size=20",
+			expectedMatch: true,
+		},
+		"should return false when url does not match (query param diff)": {
+			matchURL:      "/api/users?page=2&size=20",
+			expectedMatch: false,
+		},
+		"should return false when url does not match (missing query param)": {
+			matchURL:      "/api/users?page=1",
+			expectedMatch: false,
+		},
+		"should return false when url does not match (missing all query params)": {
+			matchURL:      "/api/users",
+			expectedMatch: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			matcher := mockaso.URL(tc.matchURL)
+			assert.Equal(t, tc.expectedMatch, matcher(httpReq.URL))
+		})
+	}
+}
+
+func TestPath(t *testing.T) {
+	t.Parallel()
+
+	reqURL := "/api/users?page=1&size=20"
+	httpReq := httptest.NewRequest(http.MethodGet, reqURL, http.NoBody)
+
+	testCases := map[string]struct {
+		matchURL      string
+		expectedMatch bool
+	}{
+		"should return true when path matched": {
+			matchURL:      "/api/users",
+			expectedMatch: true,
+		},
+		"should return true when path matched with trailing slash": {
+			matchURL:      "/api/users/",
+			expectedMatch: true,
+		},
+		"should return false when path does not match": {
+			matchURL:      "/api/users/john-doe",
+			expectedMatch: false,
+		},
+		"should return false when path does not match by including query params": {
+			matchURL:      "/api/users?page=1&size=20",
+			expectedMatch: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			matcher := mockaso.Path(tc.matchURL)
+			assert.Equal(t, tc.expectedMatch, matcher(httpReq.URL))
+		})
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1,9 +1,13 @@
 package mockaso_test
 
 import (
+	"fmt"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/royhq/mockaso"
 )
@@ -16,6 +20,10 @@ func TestServer(t *testing.T) {
 	t.Run("before start", func(t *testing.T) {
 		t.Run("should not return inner test server", func(t *testing.T) {
 			assert.Nil(t, server.TestServer())
+		})
+
+		t.Run("should not return client", func(t *testing.T) {
+			assert.Nil(t, server.Client())
 		})
 
 		t.Run("should return empty URL", func(t *testing.T) {
@@ -44,6 +52,10 @@ func TestServer(t *testing.T) {
 			assert.NotNil(t, server.TestServer())
 		})
 
+		t.Run("should return client", func(t *testing.T) {
+			assert.NotNil(t, server.Client())
+		})
+
 		t.Run("should not panic when clear", func(t *testing.T) {
 			assert.NotPanics(t, server.Clear)
 		})
@@ -67,4 +79,66 @@ func TestServer(t *testing.T) {
 			assert.NotPanics(t, server.Clear)
 		})
 	})
+}
+
+func TestServer_Stub(t *testing.T) {
+	t.Parallel()
+
+	server := mockaso.MustStartNewServer(mockaso.WithLogger(t))
+	t.Cleanup(server.MustShutdown)
+
+	client := server.Client()
+
+	server.Stub(http.MethodGet, mockaso.URL("/api/users"))
+
+	t.Run("should write response when match method and url", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "/api/users", http.NoBody)
+
+		httpResp, err := client.Do(httpReq)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+		assert.Empty(t, httpResp.Body)
+	})
+
+	t.Run("should write no matched response when no stub match by method", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodPost, "/api/users", http.NoBody)
+
+		httpResp, err := client.Do(httpReq)
+		require.NoError(t, err)
+
+		assertNotMatchedResponse(t, httpReq, httpResp)
+	})
+
+	t.Run("should write no matched response when no stub match by url", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "/api/users/john-doe", http.NoBody)
+
+		httpResp, err := client.Do(httpReq)
+		require.NoError(t, err)
+
+		assertNotMatchedResponse(t, httpReq, httpResp)
+	})
+}
+
+func assertNotMatchedResponse(t *testing.T, httpReq *http.Request, httpResp *http.Response) bool {
+	t.Helper()
+
+	expectedBody := fmt.Sprintf("no stubs for %s %s", httpReq.Method, httpReq.URL)
+
+	return assert.Equal(t, 666, httpResp.StatusCode) &&
+		assertBodyString(t, expectedBody, httpResp)
+}
+
+func assertBodyString(t *testing.T, expected string, r *http.Response) bool {
+	t.Helper()
+	return assert.Equal(t, expected, readString(r.Body))
+}
+
+func readString(r io.Reader) string {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(data)
 }

--- a/stub.go
+++ b/stub.go
@@ -1,0 +1,66 @@
+package mockaso
+
+import (
+	"net/http"
+)
+
+type (
+	StubMatcherRule  func() requestMatcherFunc
+	StubResponseRule func(*stubResponse)
+)
+
+type Stub interface {
+	StubResponder
+	Match(...StubMatcherRule) StubResponder
+}
+
+type StubResponder interface {
+	Respond(...StubResponseRule)
+}
+
+type stub struct {
+	matchers []requestMatcherFunc
+	response *stubResponse
+}
+
+func (s *stub) Match(rules ...StubMatcherRule) StubResponder {
+	for _, rule := range rules {
+		s.matchers = append(s.matchers, rule())
+	}
+
+	return s
+}
+
+func (s *stub) Respond(rules ...StubResponseRule) {
+	for _, rule := range rules {
+		rule(s.response)
+	}
+}
+
+func (s *stub) match(r *http.Request) bool {
+	for _, match := range s.matchers {
+		if !match(s, r) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *stub) write(w http.ResponseWriter) {
+	w.WriteHeader(s.response.statusCode)
+	_, _ = w.Write(s.response.body)
+}
+
+type stubResponse struct {
+	statusCode int
+	body       []byte
+	headers    map[string]string
+}
+
+func newStubResponse() *stubResponse {
+	return &stubResponse{
+		statusCode: http.StatusOK,
+		headers:    make(map[string]string),
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,31 @@
+package mockaso
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}
+
+func newTransportWithBaseURL(baseTransport http.RoundTripper, baseURL string) http.RoundTripper {
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		panic(fmt.Errorf("failed to parse base URL: %s", err))
+	}
+
+	return roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		copyRequest := *r
+
+		if !copyRequest.URL.IsAbs() { // only modify relative URL
+			copyRequest.URL = parsedBaseURL.ResolveReference(copyRequest.URL)
+			copyRequest.Host = copyRequest.URL.Host
+		}
+
+		return baseTransport.RoundTrip(&copyRequest)
+	})
+}


### PR DESCRIPTION
Added basic request matching:
- Match by HTTP Method.
- Match by URL/Path.

Added client creation with server base URL by default.
