### PR TITLE
Stub set response

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,9 +1,43 @@
 package mockaso
 
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
 type StubResponseRule func(*stubResponse)
 
+// WithStatusCode sets the response status code.
 func WithStatusCode(statusCode int) StubResponseRule {
 	return func(r *stubResponse) {
 		r.statusCode = statusCode
+	}
+}
+
+// WithBody sets the response body.
+func WithBody(body any) StubResponseRule {
+	data, err := anyBodyToBytes(body)
+	if err != nil {
+		panic(fmt.Errorf("WithBody err: failed to read body: %w", err))
+	}
+
+	return func(r *stubResponse) {
+		r.body = data
+	}
+}
+
+func anyBodyToBytes(body any) ([]byte, error) {
+	switch v := body.(type) {
+	case []byte:
+		return v, nil
+	case string:
+		return []byte(v), nil
+	case json.RawMessage:
+		return v, nil
+	case io.Reader:
+		return io.ReadAll(v)
+	default:
+		return []byte(fmt.Sprintf("%v", v)), nil
 	}
 }

--- a/response.go
+++ b/response.go
@@ -27,6 +27,25 @@ func WithBody(body any) StubResponseRule {
 	}
 }
 
+// WithHeader sets a response header.
+// If the key already exists it will be overwritten.
+func WithHeader(key, value string) StubResponseRule {
+	return func(r *stubResponse) {
+		r.headers[key] = value
+	}
+}
+
+// WithHeaders sets a set of response headers.
+// These headers will be added to the already specified headers.
+// If any key already exists it will be overwritten.
+func WithHeaders(headers map[string]string) StubResponseRule {
+	return func(r *stubResponse) {
+		for k, v := range headers {
+			r.headers[k] = v
+		}
+	}
+}
+
 func anyBodyToBytes(body any) ([]byte, error) {
 	switch v := body.(type) {
 	case []byte:

--- a/response.go
+++ b/response.go
@@ -1,0 +1,9 @@
+package mockaso
+
+type StubResponseRule func(*stubResponse)
+
+func WithStatusCode(statusCode int) StubResponseRule {
+	return func(r *stubResponse) {
+		r.statusCode = statusCode
+	}
+}

--- a/response_test.go
+++ b/response_test.go
@@ -1,8 +1,11 @@
 package mockaso_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +51,84 @@ func TestWithStatusCode(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, httpResp.StatusCode)
 	})
+}
+
+func TestWithBody(t *testing.T) {
+	t.Parallel()
+
+	server := mockaso.MustStartNewServer(mockaso.WithLogger(t))
+	t.Cleanup(server.MustShutdown)
+
+	t.Run("should return the specified body", func(t *testing.T) {
+		testCases := map[string]struct {
+			url          string
+			body         any
+			expectedBody string
+		}{
+			"bytes body": {
+				url:          "/test/bytes",
+				body:         []byte("test bytes body"),
+				expectedBody: `test bytes body`,
+			},
+			"string body": {
+				url:          "/test/string",
+				body:         "test string body",
+				expectedBody: `test string body`,
+			},
+			"int body": {
+				url:          "/test/int",
+				body:         123,
+				expectedBody: `123`,
+			},
+			"json raw body": {
+				url:          "/test/json",
+				body:         json.RawMessage(`{"name":"john"}`),
+				expectedBody: `{"name":"john"}`,
+			},
+			"string reader body": {
+				url:          "/test/string-reader",
+				body:         strings.NewReader("string reader body"),
+				expectedBody: `string reader body`,
+			},
+			"buffer body": {
+				url:          "/test/buffer",
+				body:         bytes.NewBuffer([]byte("buffer body")),
+				expectedBody: `buffer body`,
+			},
+			"map body": {
+				url:          "/test/map",
+				body:         map[string]any{"name": "john", "age": 57},
+				expectedBody: `map[age:57 name:john]`,
+			},
+			"struct body": {
+				url:          "/test/struct",
+				body:         userResponse{Name: "john", Age: 57},
+				expectedBody: `{john 57}`,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				server.Stub(http.MethodGet, mockaso.URL(tc.url)).
+					Respond(
+						mockaso.WithStatusCode(http.StatusOK),
+						mockaso.WithBody(tc.body),
+					)
+
+				httpReq, _ := http.NewRequest(http.MethodGet, tc.url, http.NoBody)
+				httpResp, err := server.Client().Do(httpReq)
+				require.NoError(t, err)
+
+				assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+				assertBodyString(t, tc.expectedBody, httpResp)
+			})
+		}
+	})
+}
+
+type userResponse struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
 }

--- a/response_test.go
+++ b/response_test.go
@@ -1,0 +1,51 @@
+package mockaso_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/royhq/mockaso"
+)
+
+func TestWithStatusCode(t *testing.T) {
+	t.Parallel()
+
+	server := mockaso.MustStartNewServer(mockaso.WithLogger(t))
+	t.Cleanup(server.MustShutdown)
+
+	t.Run("should return the specified status code", func(t *testing.T) {
+		statusCodes := []int{http.StatusOK, http.StatusCreated, http.StatusNoContent, http.StatusBadRequest,
+			http.StatusNotFound, http.StatusInternalServerError, http.StatusServiceUnavailable}
+
+		for _, statusCode := range statusCodes {
+			t.Run(fmt.Sprintf("with status code %d", statusCode), func(t *testing.T) {
+				t.Parallel()
+
+				url := fmt.Sprintf("/test/%d", statusCode)
+				server.Stub(http.MethodGet, mockaso.URL(url)).Respond(mockaso.WithStatusCode(statusCode))
+
+				httpReq, _ := http.NewRequest(http.MethodGet, url, http.NoBody)
+				httpResp, err := server.Client().Do(httpReq)
+				require.NoError(t, err)
+
+				assert.Equal(t, statusCode, httpResp.StatusCode)
+			})
+		}
+	})
+
+	t.Run("should return http 200 when status code is not specified", func(t *testing.T) {
+		t.Parallel()
+
+		server.Stub(http.MethodGet, mockaso.URL("/test"))
+
+		httpReq, _ := http.NewRequest(http.MethodGet, "/test", http.NoBody)
+		httpResp, err := server.Client().Do(httpReq)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+	})
+}

--- a/stub.go
+++ b/stub.go
@@ -4,10 +4,7 @@ import (
 	"net/http"
 )
 
-type (
-	StubMatcherRule  func() requestMatcherFunc
-	StubResponseRule func(*stubResponse)
-)
+type StubMatcherRule func() requestMatcherFunc
 
 type Stub interface {
 	StubResponder

--- a/stub.go
+++ b/stub.go
@@ -45,6 +45,10 @@ func (s *stub) match(r *http.Request) bool {
 }
 
 func (s *stub) write(w http.ResponseWriter) {
+	for k, v := range s.response.headers {
+		w.Header().Set(k, v)
+	}
+
 	w.WriteHeader(s.response.statusCode)
 	_, _ = w.Write(s.response.body)
 }


### PR DESCRIPTION
Added possibility to set response rules:
- `WithStatusCode`: sets the response status code like 2XX, 3XX, 4XX, etc.
- `WithBody`: sets the response body content.
- `WithHeader`: sets a header with the key and value.
- `WithHeaders`: sets headers with a map of key/value. 