### PR TITLE
Stub with json response

### DIFF
--- a/response.go
+++ b/response.go
@@ -35,6 +35,19 @@ func WithRawJSON[T string | []byte | json.RawMessage](raw T) StubResponseRule {
 	}
 }
 
+// WithJSON sets the response content with the marshal output of the given body.
+// The response will include the Content-Type:application/json header.
+func WithJSON(body any) StubResponseRule {
+	return func(r *stubResponse) {
+		data, err := json.Marshal(body)
+		if err != nil {
+			panic(fmt.Errorf("WithJSON err: body marshal failed: %w", err))
+		}
+
+		r.setJSON(data)
+	}
+}
+
 // WithHeader sets a response header.
 // If the key already exists it will be overwritten.
 func WithHeader(key, value string) StubResponseRule {

--- a/response.go
+++ b/response.go
@@ -30,8 +30,14 @@ func WithBody(body any) StubResponseRule {
 // WithRawJSON sets the response content with the given JSON.
 // The response will include the Content-Type:application/json header.
 func WithRawJSON[T string | []byte | json.RawMessage](raw T) StubResponseRule {
+	data := []byte(raw)
+
+	if !json.Valid(data) {
+		panic(fmt.Errorf("json is not valid: %s", data))
+	}
+
 	return func(r *stubResponse) {
-		r.setJSON([]byte(raw))
+		r.setJSON(data)
 	}
 }
 

--- a/response.go
+++ b/response.go
@@ -31,7 +31,7 @@ func WithBody(body any) StubResponseRule {
 // If the key already exists it will be overwritten.
 func WithHeader(key, value string) StubResponseRule {
 	return func(r *stubResponse) {
-		r.headers[key] = value
+		r.setHeader(key, value)
 	}
 }
 
@@ -40,9 +40,7 @@ func WithHeader(key, value string) StubResponseRule {
 // If any key already exists it will be overwritten.
 func WithHeaders(headers map[string]string) StubResponseRule {
 	return func(r *stubResponse) {
-		for k, v := range headers {
-			r.headers[k] = v
-		}
+		r.setHeaders(headers)
 	}
 }
 

--- a/response.go
+++ b/response.go
@@ -27,6 +27,14 @@ func WithBody(body any) StubResponseRule {
 	}
 }
 
+// WithRawJSON sets the response content with the given JSON.
+// The response will include the Content-Type:application/json header.
+func WithRawJSON[T string | []byte | json.RawMessage](raw T) StubResponseRule {
+	return func(r *stubResponse) {
+		r.setJSON([]byte(raw))
+	}
+}
+
 // WithHeader sets a response header.
 // If the key already exists it will be overwritten.
 func WithHeader(key, value string) StubResponseRule {

--- a/response_test.go
+++ b/response_test.go
@@ -94,7 +94,6 @@ func TestWithBody(t *testing.T) {
 				expectedBody: `map[age:57 name:john]`,
 			},
 			"struct body": {
-				//	url:          "/test/struct",
 				body:         userResponse{Name: "john", Age: 57},
 				expectedBody: `{john 57}`,
 			},

--- a/server.go
+++ b/server.go
@@ -49,11 +49,15 @@ func (s *Server) MustShutdown() {
 }
 
 func (s *Server) Clear() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.stubs = nil
+
 	if s.server == nil {
 		return
 	}
 
-	s.server.Close()
 	s.logger.Logf("server cleared at %s", s.server.URL)
 }
 

--- a/stub.go
+++ b/stub.go
@@ -69,6 +69,11 @@ func (r *stubResponse) setHeaders(headers map[string]string) {
 	}
 }
 
+func (r *stubResponse) setJSON(content []byte) {
+	r.headers["Content-Type"] = "application/json"
+	r.body = content
+}
+
 func newStubResponse() *stubResponse {
 	return &stubResponse{
 		statusCode: http.StatusOK,

--- a/stub.go
+++ b/stub.go
@@ -59,6 +59,16 @@ type stubResponse struct {
 	headers    map[string]string
 }
 
+func (r *stubResponse) setHeader(key, value string) {
+	r.headers[key] = value
+}
+
+func (r *stubResponse) setHeaders(headers map[string]string) {
+	for k, v := range headers {
+		r.headers[k] = v
+	}
+}
+
 func newStubResponse() *stubResponse {
 	return &stubResponse{
 		statusCode: http.StatusOK,


### PR DESCRIPTION
Added possibility to set json response (body and headers):
- `WithRawJSON`: sets the raw value of a json in response body.
- `WithJSON`: will marhsal the value and use it as response body.