### PR TITLE
Added http request matcher

### DIFF
--- a/match.go
+++ b/match.go
@@ -44,3 +44,13 @@ func urlMatcher(matcher URLMatcher) requestMatcherFunc {
 }
 
 type StubMatcherRule func() requestMatcherFunc
+
+type RequestMatcherFunc func(*http.Request) bool
+
+func MatchRequest(requestMatcher RequestMatcherFunc) StubMatcherRule {
+	matcher := requestMatcherFunc(func(_ *stub, r *http.Request) bool {
+		return requestMatcher(r)
+	})
+
+	return func() requestMatcherFunc { return matcher }
+}

--- a/match.go
+++ b/match.go
@@ -42,3 +42,5 @@ func urlMatcher(matcher URLMatcher) requestMatcherFunc {
 		return matcher(r.URL)
 	}
 }
+
+type StubMatcherRule func() requestMatcherFunc

--- a/stub.go
+++ b/stub.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 )
 
-type StubMatcherRule func() requestMatcherFunc
-
 type Stub interface {
 	StubResponder
 	Match(...StubMatcherRule) StubResponder


### PR DESCRIPTION
Added `MatchRequest` function. 
You can specify this rule implementing a function that compares the http.Request with your own logic and decide if the request match or not.