### PR TITLE
Added match query string and url/path regex

### DIFF
--- a/match.go
+++ b/match.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
@@ -27,6 +28,18 @@ func Path(path string) URLMatcher {
 	return func(url *url.URL) bool {
 		return url.Path == strings.TrimSuffix(path, "/")
 	}
+}
+
+// URLRegex will match http request when the regex pattern specified match to the request URL.
+func URLRegex(pattern string) URLMatcher {
+	regex := regexp.MustCompile(pattern)
+	return func(url *url.URL) bool { return regex.MatchString(url.String()) }
+}
+
+// PathRegex will match http request when the regex pattern specified match to the request URL path part.
+func PathRegex(pattern string) URLMatcher {
+	regex := regexp.MustCompile(pattern)
+	return func(url *url.URL) bool { return regex.MatchString(url.Path) }
 }
 
 func defaultMatchers(method string, url URLMatcher) []requestMatcherFunc {

--- a/match.go
+++ b/match.go
@@ -61,6 +61,15 @@ func MatchHeader(key, value string) StubMatcherRule {
 	return MatchRequest(matcher)
 }
 
+// MatchQuery sets a rule to match the http request with the given query string value.
+func MatchQuery(key, value string) StubMatcherRule {
+	matcher := RequestMatcherFunc(func(r *http.Request) bool {
+		return r.URL.Query().Get(key) == value
+	})
+
+	return MatchRequest(matcher)
+}
+
 // MatchNoBody sets a rule to match the http request with empty body.
 func MatchNoBody() StubMatcherRule {
 	matcher := RequestMatcherFunc(func(r *http.Request) bool {

--- a/match_test.go
+++ b/match_test.go
@@ -87,6 +87,49 @@ func TestPath(t *testing.T) {
 	}
 }
 
+func TestURLRegex(t *testing.T) {
+	t.Parallel()
+
+	reqURL := "/api/users?page=1&size=20"
+	httpReq := httptest.NewRequest(http.MethodGet, reqURL, http.NoBody)
+
+	regexValues := []string{
+		`\/api\/users\?page=1\&size=20`,
+		`^\/api\/users\?page=1\&size=20$`,
+		`^\/api\/users\?page=\d+\&size=\d+$`,
+		`^\/api\/[a-zA-Z]+\?page=\d+\&size=\d+$`,
+	}
+
+	for _, r := range regexValues {
+		t.Run(r, func(t *testing.T) {
+			t.Parallel()
+			matcher := mockaso.URLRegex(r)
+			assert.True(t, matcher(httpReq.URL))
+		})
+	}
+}
+
+func TestPathRegex(t *testing.T) {
+	t.Parallel()
+
+	reqURL := "/api/users?page=1&size=20"
+	httpReq := httptest.NewRequest(http.MethodGet, reqURL, http.NoBody)
+
+	regexValues := []string{
+		`\/api\/users`,
+		`^\/api\/users$`,
+		`^\/api\/[a-zA-Z]+`,
+	}
+
+	for _, r := range regexValues {
+		t.Run(r, func(t *testing.T) {
+			t.Parallel()
+			matcher := mockaso.PathRegex(r)
+			assert.True(t, matcher(httpReq.URL))
+		})
+	}
+}
+
 func TestMatchRequest(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Added:
- `URLRegex` and `PathRegex` to match URL and paths with a regex pattern.
- `MatchQuery` to match URL query string parameter.