### PR TITLE
Added slog and log loggers

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -47,7 +47,7 @@ func (l *LogLogger) Log(args ...any) {
 }
 
 func (l *LogLogger) Logf(format string, args ...any) {
-	l.logger.Println(fmt.Sprintf(format, args...))
+	l.logger.Printf(format, args...)
 }
 
 func NewLogLogger(logger *log.Logger) *LogLogger {

--- a/logging.go
+++ b/logging.go
@@ -1,5 +1,11 @@
 package mockaso
 
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
 // Logger abstraction intended for use with testing.T.
 type Logger interface {
 	Log(...any)
@@ -11,3 +17,20 @@ type noLogger struct{}
 
 func (n noLogger) Log(...any)          {}
 func (n noLogger) Logf(string, ...any) {}
+
+type SlogLogger struct {
+	logger *slog.Logger
+	level  slog.Level
+}
+
+func (l *SlogLogger) Log(args ...any) {
+	l.logger.Log(context.Background(), l.level, fmt.Sprint(args...))
+}
+
+func (l *SlogLogger) Logf(format string, args ...any) {
+	l.logger.Log(context.Background(), l.level, fmt.Sprintf(format, args...))
+}
+
+func NewSlogLogger(logger *slog.Logger, level slog.Level) *SlogLogger {
+	return &SlogLogger{logger: logger, level: level}
+}

--- a/logging.go
+++ b/logging.go
@@ -3,6 +3,7 @@ package mockaso
 import (
 	"context"
 	"fmt"
+	"log"
 	"log/slog"
 )
 
@@ -18,6 +19,7 @@ type noLogger struct{}
 func (n noLogger) Log(...any)          {}
 func (n noLogger) Logf(string, ...any) {}
 
+// SlogLogger implementation of Logger using an slog.Logger.
 type SlogLogger struct {
 	logger *slog.Logger
 	level  slog.Level
@@ -33,4 +35,21 @@ func (l *SlogLogger) Logf(format string, args ...any) {
 
 func NewSlogLogger(logger *slog.Logger, level slog.Level) *SlogLogger {
 	return &SlogLogger{logger: logger, level: level}
+}
+
+// LogLogger implementation of Logger using a log.Logger.
+type LogLogger struct {
+	logger *log.Logger
+}
+
+func (l *LogLogger) Log(args ...any) {
+	l.logger.Println(fmt.Sprint(args...))
+}
+
+func (l *LogLogger) Logf(format string, args ...any) {
+	l.logger.Println(fmt.Sprintf(format, args...))
+}
+
+func NewLogLogger(logger *log.Logger) *LogLogger {
+	return &LogLogger{logger: logger}
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,52 @@
+package mockaso_test
+
+import (
+	"bytes"
+	"log/slog"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/royhq/mockaso"
+)
+
+func TestSlogLogger(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should Log", func(t *testing.T) {
+		logger, buff := newTestSlogLogger(slog.LevelInfo)
+
+		logger.Log("test message from an slog logger!!")
+
+		logRegex := `time=[^ ]+ level=(\w+) msg="([^"]+)"`
+		regex := regexp.MustCompile(logRegex)
+		matches := regex.FindStringSubmatch(buff.String())
+
+		assert.Len(t, matches, 3)
+		assert.Equal(t, "INFO", matches[1])
+		assert.Equal(t, "test message from an slog logger!!", matches[2])
+	})
+
+	t.Run("should Logf", func(t *testing.T) {
+		logger, buff := newTestSlogLogger(slog.LevelWarn)
+
+		logger.Logf("formated test message from %s!!", "an slog logger")
+
+		logRegex := `time=[^ ]+ level=(\w+) msg="([^"]+)"`
+		regex := regexp.MustCompile(logRegex)
+		matches := regex.FindStringSubmatch(buff.String())
+
+		assert.Len(t, matches, 3)
+		assert.Equal(t, "WARN", matches[1])
+		assert.Equal(t, "formated test message from an slog logger!!", matches[2])
+	})
+}
+
+func newTestSlogLogger(level slog.Level) (*mockaso.SlogLogger, *bytes.Buffer) {
+	var buff bytes.Buffer
+	slogLogger := slog.New(slog.NewTextHandler(&buff, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := mockaso.NewSlogLogger(slogLogger, level)
+
+	return logger, &buff
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -2,6 +2,7 @@ package mockaso_test
 
 import (
 	"bytes"
+	"log"
 	"log/slog"
 	"regexp"
 	"testing"
@@ -17,7 +18,7 @@ func TestSlogLogger(t *testing.T) {
 	t.Run("should Log", func(t *testing.T) {
 		logger, buff := newTestSlogLogger(slog.LevelInfo)
 
-		logger.Log("test message from an slog logger!!")
+		logger.Log("test message from slog logger!!")
 
 		logRegex := `time=[^ ]+ level=(\w+) msg="([^"]+)"`
 		regex := regexp.MustCompile(logRegex)
@@ -25,13 +26,13 @@ func TestSlogLogger(t *testing.T) {
 
 		assert.Len(t, matches, 3)
 		assert.Equal(t, "INFO", matches[1])
-		assert.Equal(t, "test message from an slog logger!!", matches[2])
+		assert.Equal(t, "test message from slog logger!!", matches[2])
 	})
 
 	t.Run("should Logf", func(t *testing.T) {
 		logger, buff := newTestSlogLogger(slog.LevelWarn)
 
-		logger.Logf("formated test message from %s!!", "an slog logger")
+		logger.Logf("formated test message from %s!!", "slog logger")
 
 		logRegex := `time=[^ ]+ level=(\w+) msg="([^"]+)"`
 		regex := regexp.MustCompile(logRegex)
@@ -39,7 +40,26 @@ func TestSlogLogger(t *testing.T) {
 
 		assert.Len(t, matches, 3)
 		assert.Equal(t, "WARN", matches[1])
-		assert.Equal(t, "formated test message from an slog logger!!", matches[2])
+		assert.Equal(t, "formated test message from slog logger!!", matches[2])
+	})
+}
+
+func TestLogLogger(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should Log", func(t *testing.T) {
+		logger, buff := newTestLogLogger()
+
+		logger.Log("test message from logger!!")
+		assert.Equal(t, "test message from logger!!\n", buff.String())
+	})
+
+	t.Run("should Logf", func(t *testing.T) {
+		logger, buff := newTestLogLogger()
+
+		logger.Logf("formated test message from %s!!", "logger")
+
+		assert.Equal(t, "formated test message from logger!!\n", buff.String())
 	})
 }
 
@@ -47,6 +67,13 @@ func newTestSlogLogger(level slog.Level) (*mockaso.SlogLogger, *bytes.Buffer) {
 	var buff bytes.Buffer
 	slogLogger := slog.New(slog.NewTextHandler(&buff, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	logger := mockaso.NewSlogLogger(slogLogger, level)
+
+	return logger, &buff
+}
+
+func newTestLogLogger() (*mockaso.LogLogger, *bytes.Buffer) {
+	var buff bytes.Buffer
+	logger := mockaso.NewLogLogger(log.New(&buff, "", 0))
 
 	return logger, &buff
 }

--- a/server.go
+++ b/server.go
@@ -2,6 +2,8 @@ package mockaso
 
 import (
 	"fmt"
+	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -84,6 +86,10 @@ func (s *Server) Client() *http.Client {
 	return client
 }
 
+func (s *Server) Logger() Logger {
+	return s.logger
+}
+
 func (s *Server) Stub(method string, url URLMatcher) Stub {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -147,5 +153,20 @@ type ServerOption func(*Server)
 func WithLogger(logger Logger) ServerOption {
 	return func(s *Server) {
 		s.logger = logger
+	}
+}
+
+// WithSlogLogger sets a Logger from slog.Logger.
+// level is the slog.LogLevel that will be used.
+func WithSlogLogger(logger *slog.Logger, level slog.Level) ServerOption {
+	return func(s *Server) {
+		s.logger = NewSlogLogger(logger, level)
+	}
+}
+
+// WithLogLogger sets a Logger from log.Logger.
+func WithLogLogger(logger *log.Logger) ServerOption {
+	return func(s *Server) {
+		s.logger = NewLogLogger(logger)
 	}
 }


### PR DESCRIPTION
Although it is a test package and is designed for the logger to be used with the `testing.T` instance, the possibility of using `slog.Logger` and `log.Logger` is added.