### PR TITLE
Added matcher for url/path parameters

### DIFF
--- a/match.go
+++ b/match.go
@@ -107,8 +107,8 @@ func convertPatternToRegex(urlPattern string) (string, []string) {
 
 func escapeURLPattern(urlPattern string) string {
 	escaped := strings.ReplaceAll(urlPattern, "?", `\?`)
-	escaped = strings.ReplaceAll(urlPattern, "&", `\&`)
-	escaped = strings.ReplaceAll(urlPattern, "=", `\=`)
+	escaped = strings.ReplaceAll(escaped, "&", `\&`)
+	escaped = strings.ReplaceAll(escaped, "=", `\=`)
 
 	return escaped
 }

--- a/match.go
+++ b/match.go
@@ -14,18 +14,18 @@ import (
 
 type requestMatcherFunc func(*stub, *http.Request) bool
 
-type URLMatcher func(*url.URL) bool
+type URLMatcher func(*url.URL, *stub) bool
 
 // URL will match http request when the value specified is equals to the full request URL.
 func URL(u string) URLMatcher {
-	return func(url *url.URL) bool {
+	return func(url *url.URL, _ *stub) bool {
 		return u == url.String()
 	}
 }
 
 // Path will match http request when the value specified is equals to the request URL path part.
 func Path(path string) URLMatcher {
-	return func(url *url.URL) bool {
+	return func(url *url.URL, _ *stub) bool {
 		return url.Path == strings.TrimSuffix(path, "/")
 	}
 }
@@ -33,13 +33,40 @@ func Path(path string) URLMatcher {
 // URLRegex will match http request when the regex pattern specified match to the request URL.
 func URLRegex(pattern string) URLMatcher {
 	regex := regexp.MustCompile(pattern)
-	return func(url *url.URL) bool { return regex.MatchString(url.String()) }
+	return func(url *url.URL, _ *stub) bool { return regex.MatchString(url.String()) }
 }
 
 // PathRegex will match http request when the regex pattern specified match to the request URL path part.
 func PathRegex(pattern string) URLMatcher {
 	regex := regexp.MustCompile(pattern)
-	return func(url *url.URL) bool { return regex.MatchString(url.Path) }
+	return func(url *url.URL, _ *stub) bool { return regex.MatchString(url.Path) }
+}
+
+// URLPattern will match http request when the given URL pattern match to the request URL.
+// Can specify path params with {param_name} notation and then use it in matcher.
+//
+// Example:
+//
+//	URLPattern("/api/users/{user_id}")
+func URLPattern(pattern string) URLMatcher {
+	expr, paramKeys := convertPatternToRegex(pattern)
+	regex := regexp.MustCompile(expr)
+
+	return func(url *url.URL, s *stub) bool {
+		match := regex.FindStringSubmatch(url.String())
+		if match == nil {
+			return false
+		}
+
+		params := make(map[string]string)
+		for i, paramKey := range paramKeys {
+			params[paramKey] = match[i+1]
+		}
+
+		s.patternParams = params
+
+		return true
+	}
 }
 
 func defaultMatchers(method string, url URLMatcher) []requestMatcherFunc {
@@ -56,9 +83,34 @@ func methodMatcher(method string) requestMatcherFunc {
 }
 
 func urlMatcher(matcher URLMatcher) requestMatcherFunc {
-	return func(_ *stub, r *http.Request) bool {
-		return matcher(r.URL)
+	return func(st *stub, r *http.Request) bool {
+		return matcher(r.URL, st)
 	}
+}
+
+func convertPatternToRegex(urlPattern string) (string, []string) {
+	urlPattern = escapeURLPattern(urlPattern)
+
+	var paramNames []string
+
+	re := regexp.MustCompile(`\{(\w+)\}`) // to identify parameters like {param_name} within pattern
+
+	urlPattern = re.ReplaceAllStringFunc(urlPattern, func(match string) string {
+		paramName := re.FindStringSubmatch(match)[1]
+		paramNames = append(paramNames, paramName)
+
+		return fmt.Sprintf(`(?P<%s>[^/?&]+)`, paramName)
+	})
+
+	return "^" + urlPattern + "$", paramNames
+}
+
+func escapeURLPattern(urlPattern string) string {
+	escaped := strings.ReplaceAll(urlPattern, "?", `\?`)
+	escaped = strings.ReplaceAll(urlPattern, "&", `\&`)
+	escaped = strings.ReplaceAll(urlPattern, "=", `\=`)
+
+	return escaped
 }
 
 type StubMatcherRule func() requestMatcherFunc
@@ -81,6 +133,16 @@ func MatchQuery(key, value string) StubMatcherRule {
 	})
 
 	return MatchRequest(matcher)
+}
+
+// MatchParam sets a rule to match the http request with the given path param value.
+// This needs that the URL must be specified with URLPattern.
+func MatchParam(key, value string) StubMatcherRule {
+	matcher := requestMatcherFunc(func(st *stub, r *http.Request) bool {
+		return st.patternParams[key] == value
+	})
+
+	return func() requestMatcherFunc { return matcher }
 }
 
 // MatchNoBody sets a rule to match the http request with empty body.

--- a/match.go
+++ b/match.go
@@ -93,7 +93,7 @@ func convertPatternToRegex(urlPattern string) (string, []string) {
 
 	var paramNames []string
 
-	re := regexp.MustCompile(`\{(\w+)\}`) // to identify parameters like {param_name} within pattern
+	re := regexp.MustCompile(`\{(\w+)}`) // to identify parameters like {param_name} within pattern
 
 	urlPattern = re.ReplaceAllStringFunc(urlPattern, func(match string) string {
 		paramName := re.FindStringSubmatch(match)[1]

--- a/match.go
+++ b/match.go
@@ -3,6 +3,7 @@ package mockaso
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +26,8 @@ func URL(u string) URLMatcher {
 
 // Path will match http request when the value specified is equals to the request URL path part.
 func Path(path string) URLMatcher {
+	ensureHasNotQueryStringParams(path)
+
 	return func(url *url.URL, _ *stub) bool {
 		return url.Path == strings.TrimSuffix(path, "/")
 	}
@@ -44,29 +47,29 @@ func PathRegex(pattern string) URLMatcher {
 
 // URLPattern will match http request when the given URL pattern match to the request URL.
 // Can specify path params with {param_name} notation and then use it in matcher.
+// Can use parameters in query string.
 //
 // Example:
 //
 //	URLPattern("/api/users/{user_id}")
+//	URLPattern("/api/users/{user_id}?attrs={attrs}")
 func URLPattern(pattern string) URLMatcher {
-	expr, paramKeys := convertPatternToRegex(pattern)
-	regex := regexp.MustCompile(expr)
+	source := func(u *url.URL) string { return u.String() } // use complete url as source
+	return patternMatcher(source, pattern)
+}
 
-	return func(url *url.URL, s *stub) bool {
-		match := regex.FindStringSubmatch(url.String())
-		if match == nil {
-			return false
-		}
+// PathPattern will match http request when the given URL pattern match to the request URL path part.
+// Can specify path params with {param_name} notation and then use it in matcher.
+// Can't use parameters in query string, only path will be evaluated.
+//
+// Example:
+//
+//	PathPattern("/api/users/{user_id}")
+func PathPattern(pattern string) URLMatcher {
+	ensureHasNotQueryStringParams(pattern)
+	source := func(u *url.URL) string { return u.Path } // use url path as source
 
-		params := make(map[string]string)
-		for i, paramKey := range paramKeys {
-			params[paramKey] = match[i+1]
-		}
-
-		s.patternParams = params
-
-		return true
-	}
+	return patternMatcher(source, pattern)
 }
 
 func defaultMatchers(method string, url URLMatcher) []requestMatcherFunc {
@@ -85,6 +88,27 @@ func methodMatcher(method string) requestMatcherFunc {
 func urlMatcher(matcher URLMatcher) requestMatcherFunc {
 	return func(st *stub, r *http.Request) bool {
 		return matcher(r.URL, st)
+	}
+}
+
+func patternMatcher(source func(*url.URL) string, pattern string) URLMatcher {
+	expr, paramKeys := convertPatternToRegex(pattern)
+	regex := regexp.MustCompile(expr)
+
+	return func(url *url.URL, s *stub) bool {
+		match := regex.FindStringSubmatch(source(url))
+		if match == nil {
+			return false
+		}
+
+		params := make(map[string]string)
+		for i, paramKey := range paramKeys {
+			params[paramKey] = match[i+1]
+		}
+
+		s.patternParams = params
+
+		return true
 	}
 }
 
@@ -111,6 +135,17 @@ func escapeURLPattern(urlPattern string) string {
 	escaped = strings.ReplaceAll(escaped, "=", `\=`)
 
 	return escaped
+}
+
+func ensureHasNotQueryStringParams(pattern string) {
+	parsed, err := url.Parse(pattern)
+	if err != nil {
+		panic(fmt.Errorf("not valid url"))
+	}
+
+	if len(parsed.Query()) > 0 {
+		panic(errors.New("pattern must not contain any query string parameters"))
+	}
 }
 
 type StubMatcherRule func() requestMatcherFunc

--- a/match_test.go
+++ b/match_test.go
@@ -273,6 +273,27 @@ func TestMatchParam(t *testing.T) {
 		assertBodyString(t, "matched request", httpResp)
 	})
 
+	t.Run("should return the specified stub when param match in query string", func(t *testing.T) {
+		t.Parallel()
+
+		server.Stub(http.MethodGet, mockaso.URLPattern("/api/users/{username}?attrs={attrs}")).
+			Match(
+				mockaso.MatchParam("username", "john"),
+				mockaso.MatchParam("attrs", "name,age"),
+			).
+			Respond(
+				mockaso.WithStatusCode(http.StatusBadRequest),
+				mockaso.WithBody("invalid attrs"),
+			)
+
+		httpReq, _ := http.NewRequest(http.MethodGet, path+"/john?attrs=name,age", http.NoBody)
+		httpResp, err := server.Client().Do(httpReq)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, httpResp.StatusCode)
+		assertBodyString(t, "invalid attrs", httpResp)
+	})
+
 	t.Run("should return no match response when query does not match", func(t *testing.T) {
 		t.Parallel()
 

--- a/match_test.go
+++ b/match_test.go
@@ -256,10 +256,9 @@ func TestMatchParam(t *testing.T) {
 	server := mockaso.MustStartNewServer(mockaso.WithLogger(t))
 	t.Cleanup(server.MustShutdown)
 
-	urlPattern := mockaso.URLPattern("/api/users/{username}")
 	const path = "/api/users"
 
-	server.Stub(http.MethodGet, urlPattern).
+	server.Stub(http.MethodGet, mockaso.URLPattern("/api/users/{username}")).
 		Match(mockaso.MatchParam("username", "john")).
 		Respond(matchedRequestRules()...)
 

--- a/match_test.go
+++ b/match_test.go
@@ -53,38 +53,41 @@ func TestURL(t *testing.T) {
 func TestPath(t *testing.T) {
 	t.Parallel()
 
-	reqURL := "/api/users?page=1&size=20"
-	httpReq := httptest.NewRequest(http.MethodGet, reqURL, http.NoBody)
+	t.Run("should match", func(t *testing.T) {
+		reqURL := "/api/users?page=1&size=20"
+		httpReq := httptest.NewRequest(http.MethodGet, reqURL, http.NoBody)
 
-	testCases := map[string]struct {
-		matchURL      string
-		expectedMatch bool
-	}{
-		"should return true when path matched": {
-			matchURL:      "/api/users",
-			expectedMatch: true,
-		},
-		"should return true when path matched with trailing slash": {
-			matchURL:      "/api/users/",
-			expectedMatch: true,
-		},
-		"should return false when path does not match": {
-			matchURL:      "/api/users/john-doe",
-			expectedMatch: false,
-		},
-		"should return false when path does not match by including query params": {
-			matchURL:      "/api/users?page=1&size=20",
-			expectedMatch: false,
-		},
-	}
+		testCases := map[string]struct {
+			matchURL      string
+			expectedMatch bool
+		}{
+			"should return true when path matched": {
+				matchURL:      "/api/users",
+				expectedMatch: true,
+			},
+			"should return true when path matched with trailing slash": {
+				matchURL:      "/api/users/",
+				expectedMatch: true,
+			},
+			"should return false when path does not match": {
+				matchURL:      "/api/users/john-doe",
+				expectedMatch: false,
+			},
+		}
 
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			matcher := mockaso.Path(tc.matchURL)
-			assert.Equal(t, tc.expectedMatch, matcher(httpReq.URL, nil))
-		})
-	}
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				matcher := mockaso.Path(tc.matchURL)
+				assert.Equal(t, tc.expectedMatch, matcher(httpReq.URL, nil))
+			})
+		}
+	})
+
+	t.Run("should panic when path has query string parameters", func(t *testing.T) {
+		fn := func() { mockaso.Path("/api/users/john?attrs=name,age") }
+		assert.PanicsWithError(t, "pattern must not contain any query string parameters", fn)
+	})
 }
 
 func TestURLRegex(t *testing.T) {
@@ -128,6 +131,15 @@ func TestPathRegex(t *testing.T) {
 			assert.True(t, matcher(httpReq.URL, nil))
 		})
 	}
+}
+
+func TestPathPattern(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should panic when path has query string parameters", func(t *testing.T) {
+		fn := func() { mockaso.PathPattern("/api/users/{username}?attrs=name,age") }
+		assert.PanicsWithError(t, "pattern must not contain any query string parameters", fn)
+	})
 }
 
 func TestMatchRequest(t *testing.T) {
@@ -250,7 +262,7 @@ func TestMatchQuery(t *testing.T) {
 	})
 }
 
-func TestMatchParam(t *testing.T) {
+func TestMatchParam_URLPattern(t *testing.T) {
 	t.Parallel()
 
 	server := mockaso.MustStartNewServer(mockaso.WithLogger(t))
@@ -294,7 +306,41 @@ func TestMatchParam(t *testing.T) {
 		assertBodyString(t, "invalid attrs", httpResp)
 	})
 
-	t.Run("should return no match response when query does not match", func(t *testing.T) {
+	t.Run("should return no match response when param does not match", func(t *testing.T) {
+		t.Parallel()
+
+		httpReq, _ := http.NewRequest(http.MethodGet, path+"/rick", http.NoBody)
+		httpResp, err := server.Client().Do(httpReq)
+		require.NoError(t, err)
+
+		assertNotMatchedResponse(t, httpReq, httpResp)
+	})
+}
+
+func TestMatchParam_PathPattern(t *testing.T) {
+	t.Parallel()
+
+	server := mockaso.MustStartNewServer(mockaso.WithLogger(t))
+	t.Cleanup(server.MustShutdown)
+
+	const path = "/api/users"
+
+	server.Stub(http.MethodGet, mockaso.PathPattern("/api/users/{username}")).
+		Match(mockaso.MatchParam("username", "john")).
+		Respond(matchedRequestRules()...)
+
+	t.Run("should return the specified stub when param match", func(t *testing.T) {
+		t.Parallel()
+
+		httpReq, _ := http.NewRequest(http.MethodGet, path+"/john", http.NoBody)
+		httpResp, err := server.Client().Do(httpReq)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+		assertBodyString(t, "matched request", httpResp)
+	})
+
+	t.Run("should return no match response when param does not match", func(t *testing.T) {
 		t.Parallel()
 
 		httpReq, _ := http.NewRequest(http.MethodGet, path+"/rick", http.NoBody)

--- a/server.go
+++ b/server.go
@@ -94,7 +94,12 @@ func (s *Server) Stub(method string, url URLMatcher) Stub {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	st := &stub{response: newStubResponse(), matchers: defaultMatchers(method, url)}
+	st := &stub{
+		response:      newStubResponse(),
+		matchers:      defaultMatchers(method, url),
+		patternParams: make(map[string]string),
+	}
+
 	s.stubs = append(s.stubs, st)
 
 	return st

--- a/stub.go
+++ b/stub.go
@@ -14,8 +14,9 @@ type StubResponder interface {
 }
 
 type stub struct {
-	matchers []requestMatcherFunc
-	response *stubResponse
+	matchers      []requestMatcherFunc
+	response      *stubResponse
+	patternParams map[string]string
 }
 
 func (s *stub) Match(rules ...StubMatcherRule) StubResponder {


### PR DESCRIPTION
Added matcher by param.

Param must be declared like `/api/users/{user_id}`.
Then can match by the value of `user_id`.